### PR TITLE
feat: :sparkles: 하루에 여러 개의 일정을 등록, 수정, 삭제할 수 있도록 구조 변경

### DIFF
--- a/src/components/EventModal.tsx
+++ b/src/components/EventModal.tsx
@@ -1,80 +1,116 @@
 import "../styles/main.scss";
 import { Event } from "../types/event";
+import { useState } from "react";
 
+// Props 타입 정의 - 여러 일정 관리
 interface EventModalProps {
   isOpen: boolean;
   onClose: () => void;
   selectedDate: string;
-  newEvent: Event;
-  setNewEvent: (event: Event) => void;
-  isEditing: boolean;
-  handleSaveEvent: () => void;
-  handleDeleteEvent: () => void;
+  selectedEvents: Event[]; // 여러 개의 이벤트 배열
+  setSelectedEvents: (events: Event[]) => void;
+  handleSaveAllEvents: () => void; // 전체 저장
+  handleDeleteEvent: (id: number) => void; // ✅ 특정 id 삭제
 }
-
-import { useState } from "react";
 
 const EventModal = ({
   isOpen,
   onClose,
   selectedDate,
-  newEvent,
-  setNewEvent,
-  isEditing,
-  handleSaveEvent,
+  selectedEvents,
+  setSelectedEvents,
+  handleSaveAllEvents,
   handleDeleteEvent,
 }: EventModalProps) => {
   const [error, setError] = useState("");
 
+  // 모달이 닫혀있으면 렌더링하지 않음
   if (!isOpen) return null;
 
+  // 새 일정 추가 버튼 클릭
+  const handleAddEvent = () => {
+    const newId = Date.now();
+    const newEvent: Event = {
+      id: newId,
+      title: "",
+      date: selectedDate,
+      reminder: "",
+    };
+    setSelectedEvents([...selectedEvents, newEvent]);
+  };
+
+  // 입력값 변경 핸들러
+  const handleChange = (
+    id: number,
+    field: "title" | "reminder",
+    value: string
+  ) => {
+    const newEvents = selectedEvents.map((event) =>
+      event.id === id ? { ...event, [field]: value } : event
+    );
+    setSelectedEvents(newEvents);
+  };
+
+  // 저장 (전체 저장) 버튼 클릭 시 유효성 검사 후 저장
   const handleSubmit = () => {
-    if (!newEvent.title.trim()) {
-      setError("제목을 입력해주세요.");
-      return;
-    }
-    if (!newEvent.reminder) {
-      setError("시간을 선택해주세요.");
+    const hasInvalid = selectedEvents.some(
+      (event) => !event.title.trim() || !event.reminder
+    );
+    if (hasInvalid) {
+      setError("모든 일정에 제목과 시간을 입력해주세요.");
       return;
     }
 
-    // 유효성 검사 통과
     setError(""); // 에러 초기화
-    handleSaveEvent();
+    handleSaveAllEvents();
   };
 
   return (
     <>
+      {/* 오버레이 클릭 시 모달 닫힘 */}
       <div className="modal-overlay" onClick={onClose}></div>
+
+      {/* 모달 박스 */}
       <div className="modal">
-        <h3>{selectedDate} 일정</h3>
+        <h3>{selectedDate} </h3>
 
-        <input
-          type="text"
-          placeholder="일정 제목"
-          value={newEvent.title}
-          onChange={(e) => setNewEvent({ ...newEvent, title: e.target.value })}
-        />
+        {/* 여러 일정 렌더링 */}
+        {selectedEvents.map((event) => (
+          <div key={event.id} className="event-item">
+            <input
+              type="text"
+              placeholder="일정 제목"
+              value={event.title}
+              onChange={(e) => handleChange(event.id, "title", e.target.value)}
+            />
+            <input
+              type="time"
+              value={event.reminder}
+              onChange={(e) =>
+                handleChange(event.id, "reminder", e.target.value)
+              }
+            />
+            <button
+              className="delete-button"
+              onClick={() => handleDeleteEvent(event.id)}
+            >
+              삭제
+            </button>
+          </div>
+        ))}
 
-        <input
-          type="time"
-          value={newEvent.reminder}
-          onChange={(e) =>
-            setNewEvent({ ...newEvent, reminder: e.target.value })
-          }
-        />
-
-        {error && <p className="error-message">{error}</p>}
-
-        <button className="save-button" onClick={handleSubmit}>
-          {isEditing ? "수정" : "저장"}
+        {/* 새 일정 추가 버튼 */}
+        <button className="add-button" onClick={handleAddEvent}>
+          + 새 일정 추가
         </button>
 
-        {isEditing && (
-          <button className="delete-button" onClick={handleDeleteEvent}>
-            삭제
-          </button>
-        )}
+        {/* 에러 메시지 */}
+        {error && <p className="error-message">{error}</p>}
+
+        {/* 전체 저장 및 닫기 버튼 */}
+        <button className="save-button" onClick={handleSubmit}>
+          전체 저장
+        </button>
         <button className="close-button" onClick={onClose}>
           닫기
         </button>

--- a/src/styles/_events.scss
+++ b/src/styles/_events.scss
@@ -20,11 +20,6 @@
     color: color.scale(variables.$primary-color);
     cursor: pointer;
   }
-
-  .delete-button {
-    color: red;
-    cursor: pointer;
-  }
 }
 
 .error-message {


### PR DESCRIPTION
1. 캘린더 구조 리팩토링
 1.1 기존: 하루에 단일 이벤트만 등록 가능한 구조
 1.2 개선: 하루에 여러 개의 일정을 등록, 수정, 삭제할 수 있도록 구조 변경
2. Calendar.tsx 리팩토링
 2.1 newEvent, isEditing 상태 제거 → selectedEvents: Event[] 배열로 대체
 2.2 날짜 클릭 시 selectedEvents 배열에 해당 날짜의 모든 일정 저장
 2.3 handleSaveAllEvents()로 여러 일정 일괄 저장 처리
 2.4 handleDeleteEvent(id)로 개별 삭제 처리
3. EventModal.tsx 전면 리팩토링
 3.1 기존 단일 일정 → 여러 일정 동시 렌더링 및 관리
 3.2 selectedEvents.map()으로 입력 필드 반복 렌더링
 3.3 handleAddEvent()로 새 일정 추가
 3.4 handleChange()로 개별 입력값 변경 처리
 3.5 handleDeleteEvent(id)로 일정 삭제
 3.6 handleSubmit()에서 유효성 검사 후 전체 저장
4. TypeScript 타입 문제 해결
 4.1 handleDeleteEvent: (id: number) => void로 타입 명확화
 4.2 handleChange() 함수는 명시적 조건 분기 방식 (if (field === "title")) 으로 안전하게 처리